### PR TITLE
Stream.Connection 클래스에서 불필요한 코드 제거

### DIFF
--- a/src/Flip/Stream.cs
+++ b/src/Flip/Stream.cs
@@ -170,12 +170,7 @@ namespace Flip
                               select m;
                 _subscription = _stream.Subscribe(_subject);
             }
-
-            ~Connection()
-            {
-                Dispose();
-            }
-
+            
             public TId ModelId => _stream.ModelId;
 
             public void Emit(IObservable<TModel> source)
@@ -201,7 +196,6 @@ namespace Flip
             public void Dispose()
             {
                 _subscription.Dispose();
-                GC.SuppressFinalize(this);
             }
         }
 


### PR DESCRIPTION
#5 에서 제기한 바와 같이 불필요한 `finalizer`와 `GC.SuppressFinalize(this)`를 제거하였습니다.