### PR TITLE
ObservableExtensions 클래스 IScheduler 적용

### DIFF
--- a/src/Flip.Mvvm/ObservableExtensions.cs
+++ b/src/Flip.Mvvm/ObservableExtensions.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 
 namespace Flip
@@ -17,9 +18,8 @@ namespace Flip
         {
             var body = expression as MemberExpression;
             if (body != null)
-            {
                 return body.Member.Name;
-            }
+
             if (expression.NodeType == ExpressionType.Convert)
             {
                 var unaryExpression = expression as UnaryExpression;
@@ -29,13 +29,15 @@ namespace Flip
                     return body.Member.Name;
                 }
             }
+
             return null;
         }
 
         private static IObservable<TProperty> ObserveImpl
             <TComponent, TProperty>(
             TComponent component,
-            Expression<Func<TComponent, TProperty>> propertyExpression)
+            Expression<Func<TComponent, TProperty>> propertyExpression,
+            IScheduler scheduler)
             where TComponent : INotifyPropertyChanged
         {
             string propertyName = GetMemberName(propertyExpression.Body);
@@ -50,13 +52,51 @@ namespace Flip
 
             IObservable<TComponent> source =
                 from e in Observable.FromEventPattern<PropertyChangedEventArgs>(
-                    component, nameof(component.PropertyChanged))
+                    component, nameof(component.PropertyChanged), scheduler)
                 where e.EventArgs.PropertyName == propertyName
                 select component;
 
             return Observable
-                .Start(() => compiled.Invoke(component))
+                .Start(() => compiled.Invoke(component), scheduler)
                 .Concat(source.Select(compiled));
+        }
+
+        /// <summary>
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체의
+        /// 지정한 속성을 관찰합니다.
+        /// </summary>
+        /// <typeparam name="TComponent">
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체 형식입니다.
+        /// </typeparam>
+        /// <typeparam name="TProperty">관찰할 속성의 형식입니다.</typeparam>
+        /// <param name="component"><see cref="INotifyPropertyChanged"/>
+        /// 인터페이스 구현체입니다.
+        /// </param>
+        /// <param name="propertyExpression">
+        /// 관찰할 속성을 표현하는 식입니다.
+        /// </param>
+        /// <param name="scheduler">이벤트를 구독할 스케줄러입니다.</param>
+        /// <returns>
+        /// <paramref name="propertyExpression"/>이 표현하는 속성 값의
+        /// 변화를 노출하는 <see cref="IObservable{T}"/>입니다.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// 매개변수 propertyExpression이 올바른 속성 표현식이 아닌 경우
+        /// </exception>
+        public static IObservable<TProperty> Observe<TComponent, TProperty>(
+            this TComponent component,
+            Expression<Func<TComponent, TProperty>> propertyExpression,
+            IScheduler scheduler)
+            where TComponent : INotifyPropertyChanged
+        {
+            if (component == null)
+                throw new ArgumentNullException(nameof(component));
+            if (propertyExpression == null)
+                throw new ArgumentNullException(nameof(propertyExpression));
+            if (scheduler == null)
+                throw new ArgumentNullException(nameof(scheduler));
+
+            return ObserveImpl(component, propertyExpression, scheduler);
         }
 
         /// <summary>
@@ -83,18 +123,53 @@ namespace Flip
         public static IObservable<TProperty> Observe<TComponent, TProperty>(
             this TComponent component,
             Expression<Func<TComponent, TProperty>> propertyExpression)
+            where TComponent : INotifyPropertyChanged =>
+            Observe(component, propertyExpression, Scheduler.Default);
+
+        /// <summary>
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체의
+        /// 지정한 속성의 투영 값을 관찰합니다.
+        /// </summary>
+        /// <typeparam name="TComponent">
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체 형식입니다.
+        /// </typeparam>
+        /// <typeparam name="TProperty">관찰할 속성의 형식입니다.</typeparam>
+        /// <typeparam name="TResult">속성 투영 값 형식입니다.</typeparam>
+        /// <param name="component"><see cref="INotifyPropertyChanged"/>
+        /// 인터페이스 구현체입니다.
+        /// </param>
+        /// <param name="propertyExpression">
+        /// 관찰할 속성을 표현하는 식입니다.
+        /// </param>
+        /// <param name="selector">속성 값을 투영하는 함수입니다.</param>
+        /// <param name="scheduler">이벤트를 구독할 스케줄러입니다.</param>
+        /// <returns>
+        /// <paramref name="propertyExpression"/>이 표현하는 속성 값의
+        /// 투영 결과를 노출하는 <see cref="IObservable{T}"/>입니다.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// 매개변수 propertyExpression이 올바른 속성 표현식이 아닌 경우
+        /// </exception>
+        public static IObservable<TResult> Observe
+            <TComponent, TProperty, TResult>(
+            this TComponent component,
+            Expression<Func<TComponent, TProperty>> propertyExpression,
+            Func<TProperty, TResult> selector,
+            IScheduler scheduler)
             where TComponent : INotifyPropertyChanged
         {
             if (component == null)
-            {
                 throw new ArgumentNullException(nameof(component));
-            }
             if (propertyExpression == null)
-            {
                 throw new ArgumentNullException(nameof(propertyExpression));
-            }
+            if (selector == null)
+                throw new ArgumentNullException(nameof(selector));
+            if (scheduler == null)
+                throw new ArgumentNullException(nameof(scheduler));
 
-            return ObserveImpl(component, propertyExpression);
+            IObservable<TProperty> source = ObserveImpl(
+                component, propertyExpression, scheduler);
+            return source.Select(selector);
         }
 
         /// <summary>
@@ -125,22 +200,7 @@ namespace Flip
             this TComponent component,
             Expression<Func<TComponent, TProperty>> propertyExpression,
             Func<TProperty, TResult> selector)
-            where TComponent : INotifyPropertyChanged
-        {
-            if (component == null)
-            {
-                throw new ArgumentNullException(nameof(component));
-            }
-            if (propertyExpression == null)
-            {
-                throw new ArgumentNullException(nameof(propertyExpression));
-            }
-            if (selector == null)
-            {
-                throw new ArgumentNullException(nameof(selector));
-            }
-
-            return ObserveImpl(component, propertyExpression).Select(selector);
-        }
+            where TComponent : INotifyPropertyChanged =>
+            Observe(component, propertyExpression, selector, Scheduler.Default);
     }
 }

--- a/tests/Flip.Tests/StreamTest.cs
+++ b/tests/Flip.Tests/StreamTest.cs
@@ -12,6 +12,7 @@ using Xunit;
 
 namespace Flip.Tests
 {
+    using System.Reactive.Concurrency;
     using static It;
     using static Stream<User, string>;
     using static Times;
@@ -46,8 +47,12 @@ namespace Flip.Tests
         [Theory, AutoData]
         public void ConnectReturnsConnection(string id)
         {
+            // Arrange
+
+            // Act
             IConnection<User, string> connection = Connect(id);
 
+            // Assert
             connection.Should().NotBeNull();
             connection.ModelId.Should().Be(id);
         }
@@ -57,7 +62,7 @@ namespace Flip.Tests
         {
             IConnection<User, string> connection = Connect(user.Id);
             var observer = Mock.Of<IObserver<User>>();
-            connection.Subscribe(observer);
+            connection.SubscribeOn(Scheduler.Immediate).Subscribe(observer);
 
             Connect(user.Id).Emit(user);
 


### PR DESCRIPTION
`ObservableExtensions` 클래스의 확장 메서드에 스케줄러를 적용합니다.

This resolves #8 